### PR TITLE
Find C#/VB targets using MSBuildToolsVersion

### DIFF
--- a/src/Sunburst.NET.Sdk.WPF/Sdk/Sdk.targets
+++ b/src/Sunburst.NET.Sdk.WPF/Sdk/Sdk.targets
@@ -8,7 +8,7 @@
     <_SdkVisualStudioVersion Condition="'$(_SdkVisualStudioVersion)' == '' or '$(_SdkVisualStudioVersion)' &lt; '14.0' ">15.0</_SdkVisualStudioVersion>
 
     <!-- Workaround for lack of XAML support in the new project system -->
-    <LanguageTargets Condition="'$(_SdkLanguageName)' != 'FSharp'">$(MSBuildExtensionsPath)\$(_SdkVisualStudioVersion)\Bin\Microsoft.$(_SdkLanguageName).targets</LanguageTargets>
+    <LanguageTargets Condition="'$(_SdkLanguageName)' != 'FSharp'">$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Bin\Microsoft.$(_SdkLanguageName).targets</LanguageTargets>
     <LanguageTargets Condition="'$(_SdkLanguageName)' == 'FSharp'">$(MSBuildExtensionsPath)\Microsoft\VisualStudio\v$(_SdkVisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</LanguageTargets>
 
     <!-- Don't generate assembly info for *.tmp_proj files -->


### PR DESCRIPTION
Adds support for Visual Studio 2019 by using `MSBuildToolsVersion` instead of` VisualStudioVersion`, since they no longer match after Microsoft/msbuild#3778.

This is a port of https://github.com/onovotny/MSBuildSdkExtras/pull/128.

This change does not break Visual Studio 2017 compatibility: there, the two variables have the same value `15.0`. In 2019, they differ.